### PR TITLE
Allow passing arguments through

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"p-try": "^1.0.0"
+		"p-try": "^2.0.0"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -44,15 +44,21 @@ Minimum: `1`
 
 Concurrency limit.
 
-### limit(fn)
+### limit(fn, ...args)
 
-Returns the promise returned by calling `fn`.
+Returns the promise returned by calling `fn(...args)`.
 
 #### fn
 
 Type: `Function`
 
 Promise-returning/async function.
+
+#### ...args
+
+Any arguments to pass through to `fn`.
+
+Support for passing arguments on to the `fn` is provided in order to be able to avoid creating unnecessary closures. You probably don't need this optimization unless you're pushing a *lot* of functions.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -60,3 +60,10 @@ test('continues after sync throw', async t => {
 
 	t.is(ran, true);
 });
+
+test('can give additional arguments', async t => {
+	const limit = m(1);
+	const symbol = Symbol('test');
+
+	await limit(a => t.is(a, symbol), symbol);
+});

--- a/test.js
+++ b/test.js
@@ -61,7 +61,7 @@ test('continues after sync throw', async t => {
 	t.is(ran, true);
 });
 
-test('can give additional arguments', async t => {
+test('accepts additional arguments', async t => {
 	const limit = m(1);
 	const symbol = Symbol('test');
 


### PR DESCRIPTION
I had some problems when trying to limit a function which I was calling _a lot_. My process would run out of memory before even starting to do anything at all, just from all new functions that had to be allocated when enqueuing all of the functions.

This pull request makes two changes. Firstly, it adds the ability to pass in arguments to the returned, limited, function that will then be passed through into the passed function. This allows consumers of this library to pass in generic functions, instead of allocating a new generalized function for each call.

Secondly, it minimizes the number of, and size of, functions being allocated when running the returned, limited, function. When running the library with a no-op function, I'm seeing **~44% less memory used**, and ~22% less time spent.