### PR TITLE
Add `activeCount` and `pendingCount` properties to the limited function

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,14 @@ module.exports = concurrency => {
 	};
 
 	const generator = (fn, ...args) => new Promise(resolve => enqueue(fn, resolve, ...args));
-	generator.activeCount = () => activeCount;
-	generator.pendingCount = () => queue.length;
+	Object.defineProperties(generator, {
+		activeCount: {
+			get: () => activeCount
+		},
+		pendingCount: {
+			get: () => queue.length
+		}
+	});
 
 	return generator;
 };

--- a/index.js
+++ b/index.js
@@ -33,7 +33,11 @@ module.exports = concurrency => {
 		} else {
 			queue.push(run.bind(null, fn, resolve, ...args));
 		}
-	};
+  };
+  
+  const generator = (fn, ...args) => new Promise(resolve => enqueue(fn, resolve, ...args));
+  generator.activeCount = () => activeCount;
+  generator.pendingCount = () => queue.length;
 
-	return (fn, ...args) => new Promise(resolve => enqueue(fn, resolve, ...args));
+	return generator;
 };

--- a/index.js
+++ b/index.js
@@ -33,11 +33,11 @@ module.exports = concurrency => {
 		} else {
 			queue.push(run.bind(null, fn, resolve, ...args));
 		}
-  };
-  
-  const generator = (fn, ...args) => new Promise(resolve => enqueue(fn, resolve, ...args));
-  generator.activeCount = () => activeCount;
-  generator.pendingCount = () => queue.length;
+	};
+
+	const generator = (fn, ...args) => new Promise(resolve => enqueue(fn, resolve, ...args));
+	generator.activeCount = () => activeCount;
+	generator.pendingCount = () => queue.length;
 
 	return generator;
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"await",
 		"promises",
 		"bluebird"
-    ],
+	],
 	"dependencies": {
 		"p-try": "^2.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
 		"promises",
 		"bluebird"
     ],
-    "x": {
-        "space": true
-    },
 	"dependencies": {
 		"p-try": "^2.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
 		"await",
 		"promises",
 		"bluebird"
-	],
+    ],
+    "x": {
+        "space": true
+    },
 	"dependencies": {
 		"p-try": "^2.0.0"
 	},

--- a/readme.md
+++ b/readme.md
@@ -60,13 +60,13 @@ Any arguments to pass through to `fn`.
 
 Support for passing arguments on to the `fn` is provided in order to be able to avoid creating unnecessary closures. You probably don't need this optimization unless you're pushing a *lot* of functions.
 
-### limit.activeCount()
+### limit.activeCount
 
-Returns the number of promises that are currently running.
+The number of promises that are currently running.
 
-### limit.pendingCount()
+### limit.pendingCount
 
-Returns the number of promises that are waiting to run (i.e. their internal `fn` was not called yet).
+The number of promises that are waiting to run (i.e. their internal `fn` was not called yet).
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,13 @@ Any arguments to pass through to `fn`.
 
 Support for passing arguments on to the `fn` is provided in order to be able to avoid creating unnecessary closures. You probably don't need this optimization unless you're pushing a *lot* of functions.
 
+### limit.activeCount()
+
+Returns the number of promises that are currently running.
+
+### limit.pendingCount()
+
+Returns the number of promises that are waiting to run (i.e. their internal `fn` was not called yet).
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -70,29 +70,29 @@ test('accepts additional arguments', async t => {
 
 test('test values of activeCount and pendingCount', async t => {
 	const limit = m(5);
-	t.is(limit.activeCount(), 0);
-	t.is(limit.pendingCount(), 0);
+	t.is(limit.activeCount, 0);
+	t.is(limit.pendingCount, 0);
 
 	const runningPromise1 = limit(() => delay(1000));
-	t.is(limit.activeCount(), 1);
-	t.is(limit.pendingCount(), 0);
+	t.is(limit.activeCount, 1);
+	t.is(limit.pendingCount, 0);
 
 	await runningPromise1;
-	t.is(limit.activeCount(), 0);
-	t.is(limit.pendingCount(), 0);
+	t.is(limit.activeCount, 0);
+	t.is(limit.pendingCount, 0);
 
 	const immediatePromises = Array.from({length: 5}, () => limit(() => delay(1000)));
 	const delayedPromises = Array.from({length: 3}, () => limit(() => delay(1000)));
 
-	t.is(limit.activeCount(), 5);
-	t.is(limit.pendingCount(), 3);
+	t.is(limit.activeCount, 5);
+	t.is(limit.pendingCount, 3);
 
 	await Promise.all(immediatePromises);
-	t.is(limit.activeCount(), 3);
-	t.is(limit.pendingCount(), 0);
+	t.is(limit.activeCount, 3);
+	t.is(limit.pendingCount, 0);
 
 	await Promise.all(delayedPromises);
 
-	t.is(limit.activeCount(), 0);
-	t.is(limit.pendingCount(), 0);
+	t.is(limit.activeCount, 0);
+	t.is(limit.pendingCount, 0);
 });

--- a/test.js
+++ b/test.js
@@ -81,8 +81,8 @@ test('test values of activeCount and pendingCount', async t => {
 	t.is(limit.activeCount(), 0);
 	t.is(limit.pendingCount(), 0);
 
-	const immediatePromises = Array.from({ length: 5 }, () => limit(() => delay(1000)));
-	const delayedPromises = Array.from({ length: 3 }, () => limit(() => delay(1000)));
+	const immediatePromises = Array.from({length: 5}, () => limit(() => delay(1000)));
+	const delayedPromises = Array.from({length: 3}, () => limit(() => delay(1000)));
 
 	t.is(limit.activeCount(), 5);
 	t.is(limit.pendingCount(), 3);

--- a/test.js
+++ b/test.js
@@ -69,30 +69,30 @@ test('accepts additional arguments', async t => {
 });
 
 test('test values of activeCount and pendingCount', async t => {
-  const limit = m(5);
-  t.is(limit.activeCount(), 0);
-  t.is(limit.pendingCount() , 0);
+	const limit = m(5);
+	t.is(limit.activeCount(), 0);
+	t.is(limit.pendingCount(), 0);
 
-  const runningPromise1 = limit(() => delay(1000));
-  t.is(limit.activeCount(), 1);
-  t.is(limit.pendingCount(), 0);
+	const runningPromise1 = limit(() => delay(1000));
+	t.is(limit.activeCount(), 1);
+	t.is(limit.pendingCount(), 0);
 
-  await runningPromise1;
-  t.is(limit.activeCount(), 0);
-  t.is(limit.pendingCount(), 0);
+	await runningPromise1;
+	t.is(limit.activeCount(), 0);
+	t.is(limit.pendingCount(), 0);
 
-  const immediatePromises = Array.from({ length: 5 }, () => limit(() => delay(1000)));
-  const delayedPromises = Array.from({ length: 3 }, () => limit(() => delay(1000)));
+	const immediatePromises = Array.from({ length: 5 }, () => limit(() => delay(1000)));
+	const delayedPromises = Array.from({ length: 3 }, () => limit(() => delay(1000)));
 
-  t.is(limit.activeCount(), 5);
-  t.is(limit.pendingCount(), 3);
+	t.is(limit.activeCount(), 5);
+	t.is(limit.pendingCount(), 3);
 
-  await Promise.all(immediatePromises);
-  t.is(limit.activeCount(), 3);
-  t.is(limit.pendingCount(), 0);
+	await Promise.all(immediatePromises);
+	t.is(limit.activeCount(), 3);
+	t.is(limit.pendingCount(), 0);
 
-  await Promise.all(delayedPromises);
+	await Promise.all(delayedPromises);
 
-  t.is(limit.activeCount(), 0);
-  t.is(limit.pendingCount(), 0);
+	t.is(limit.activeCount(), 0);
+	t.is(limit.pendingCount(), 0);
 });

--- a/test.js
+++ b/test.js
@@ -67,3 +67,32 @@ test('accepts additional arguments', async t => {
 
 	await limit(a => t.is(a, symbol), symbol);
 });
+
+test('test values of activeCount and pendingCount', async t => {
+  const limit = m(5);
+  t.is(limit.activeCount(), 0);
+  t.is(limit.pendingCount() , 0);
+
+  const runningPromise1 = limit(() => delay(1000));
+  t.is(limit.activeCount(), 1);
+  t.is(limit.pendingCount(), 0);
+
+  await runningPromise1;
+  t.is(limit.activeCount(), 0);
+  t.is(limit.pendingCount(), 0);
+
+  const immediatePromises = Array.from({ length: 5 }, () => limit(() => delay(1000)));
+  const delayedPromises = Array.from({ length: 3 }, () => limit(() => delay(1000)));
+
+  t.is(limit.activeCount(), 5);
+  t.is(limit.pendingCount(), 3);
+
+  await Promise.all(immediatePromises);
+  t.is(limit.activeCount(), 3);
+  t.is(limit.pendingCount(), 0);
+
+  await Promise.all(delayedPromises);
+
+  t.is(limit.activeCount(), 0);
+  t.is(limit.pendingCount(), 0);
+});

--- a/test.js
+++ b/test.js
@@ -88,7 +88,7 @@ test('does not ignore errors', async t => {
 	await t.throwsAsync(Promise.all(promises), {is: error});
 });
 
-test('test values of activeCount and pendingCount', async t => {
+test('activeCount and pendingCount properties', async t => {
 	const limit = m(5);
 	t.is(limit.activeCount, 0);
 	t.is(limit.pendingCount, 0);


### PR DESCRIPTION
In many cases you would want to know how many tasks are in the queue, for example to avoid adding too many tasks and cause memory overflow (i.e. DDOS).
I know that this could be implemented with p-queue instead, but sometimes you only need this specific feature without the overhead of the whole p-queue package.

I even added tests 😀 