### PR TITLE
Add limit.wait

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,11 @@ export interface Limit {
 	Note: This does not cancel promises that are already running.
 	*/
 	clearQueue(): void;
+
+	/**
+    Returns a Promise that will resolve the next time the pending and active counts are zero.  This can be useful during teardown if you would prefer to wait until everything has completed.
+	*/
+	wait(): Promise<void>;
 }
 
 /**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,3 +18,5 @@ expectType<number>(limit.activeCount);
 expectType<number>(limit.pendingCount);
 
 expectType<void>(limit.clearQueue());
+
+expectType<Promise<void>>(limit.wait());

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,10 @@ This might be useful if you want to teardown the queue at the end of your progra
 
 Note: This does not cancel promises that are already running.
 
+### limit.wait()
+
+Returns a Promise that will resolve the next time the pending and active counts are zero.  This can be useful during teardown if you would prefer to wait until everything has completed.
+
 ## FAQ
 
 ### How is this different from the [`p-queue`](https://github.com/sindresorhus/p-queue) package?

--- a/test.js
+++ b/test.js
@@ -132,6 +132,22 @@ test('clearQueue', t => {
 	t.is(limit.pendingCount, 0);
 });
 
+test('wait', async t => {
+	const limit = pLimit(1);
+
+	Array.from({length: 1}, () => limit(() => delay(1000)));
+	Array.from({length: 3}, () => limit(() => delay(1000)));
+
+	t.is(limit.activeCount, 1);
+	t.is(limit.pendingCount, 3);
+	await limit.wait();
+	t.is(limit.activeCount, 0);
+	t.is(limit.pendingCount, 0);
+	await limit.wait();
+	t.is(limit.activeCount, 0);
+	t.is(limit.pendingCount, 0);
+});
+
 test('throws on invalid concurrency argument', async t => {
 	await t.throwsAsync(pLimit(0));
 	await t.throwsAsync(pLimit(-1));


### PR DESCRIPTION
This adds a new function property to `limit`, `wait()`.  This will wait until all active or pending calls have completed (rather than just discarding them as `clearQueue()` does).