### PR TITLE
fix(clearQueue): reject pending promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,9 @@ const pLimit = concurrency => {
 		},
 		clearQueue: {
 			value: () => {
-				queue.forEach(({reject}) => reject(new Error('queue cleared before function was invoked')));
+				for (const {reject} of queue) {
+					reject(new Error('Queue cleared before function was invoked'));
+				}
 				queue.length = 0;
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ const pLimit = concurrency => {
 				for (const {reject} of queue) {
 					reject(new Error('Queue cleared before function was invoked'));
 				}
+
 				queue.length = 0;
 			}
 		}

--- a/test.js
+++ b/test.js
@@ -130,13 +130,14 @@ test('clearQueue', async t => {
 	const limit = pLimit(1);
 
 	Array.from({length: 1}, () => limit(() => delay(1000)));
-	Array.from({length: 3}, () => limit(() => delay(1000)).catch(
-		error => t.is(error.message, 'queue cleared before function was invoked')
-	));
+	const pendingPromises = Array.from({length: 3},
+		() => t.throwsAsync(limit(() => delay(1000)), 'queue cleared before function was invoked')
+	);
 
 	await Promise.resolve();
 	t.is(limit.pendingCount, 3);
 	limit.clearQueue();
+	await Promise.all(pendingPromises);
 	t.is(limit.pendingCount, 0);
 });
 

--- a/test.js
+++ b/test.js
@@ -130,7 +130,9 @@ test('clearQueue', async t => {
 	const limit = pLimit(1);
 
 	Array.from({length: 1}, () => limit(() => delay(1000)));
-	Array.from({length: 3}, () => limit(() => delay(1000)));
+	Array.from({length: 3}, () => limit(() => delay(1000)).catch(
+		error => t.is(error.message, 'queue cleared before function was invoked')
+	));
 
 	await Promise.resolve();
 	t.is(limit.pendingCount, 3);

--- a/test.js
+++ b/test.js
@@ -131,7 +131,7 @@ test('clearQueue', async t => {
 
 	Array.from({length: 1}, () => limit(() => delay(1000)));
 	const pendingPromises = Array.from({length: 3},
-		() => t.throwsAsync(limit(() => delay(1000)), 'queue cleared before function was invoked')
+		() => t.throwsAsync(limit(() => delay(1000)), 'Queue cleared before function was invoked')
 	);
 
 	await Promise.resolve();


### PR DESCRIPTION
Here's what I meant in #25

BREAKING CHANGE: when clearQueue() is called, promises for queued function calls will be rejected.

fix #25