### PR TITLE
Always run limited functions asynchronously

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,11 +28,12 @@ const pLimit = concurrency => {
 	};
 
 	const enqueue = (fn, resolve, ...args) => {
-		if (activeCount < concurrency) {
-			run(fn, resolve, ...args);
-		} else {
-			queue.push(run.bind(null, fn, resolve, ...args));
-		}
+		queue.push(run.bind(null, fn, resolve, ...args));
+		Promise.resolve().then(() => {
+			if (activeCount < concurrency && queue.length > 0) {
+				queue.shift()();
+			}
+		});
 	};
 
 	const generator = (fn, ...args) => new Promise(resolve => enqueue(fn, resolve, ...args));

--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ const pLimit = concurrency => {
 	const enqueue = (fn, resolve, ...args) => {
 		queue.push(run.bind(null, fn, resolve, ...args));
 		(async () => {
+			// This function needs to wait until the next micro-task before comparing
+			// activeCount to concurrency, because activeCount is updated asynchronously
+			// when the run function is dequeued and called. The comparison in the if-statement
+			// needs to happen asynchronously as well to get an up-to-date value for activeCount.
 			await Promise.resolve();
 			if (activeCount < concurrency && queue.length > 0) {
 				queue.shift()();

--- a/index.js
+++ b/index.js
@@ -29,11 +29,12 @@ const pLimit = concurrency => {
 
 	const enqueue = (fn, resolve, ...args) => {
 		queue.push(run.bind(null, fn, resolve, ...args));
-		Promise.resolve().then(() => {
+		(async () => {
+			await Promise.resolve();
 			if (activeCount < concurrency && queue.length > 0) {
 				queue.shift()();
 			}
-		});
+		})();
 	};
 
 	const generator = (fn, ...args) => new Promise(resolve => enqueue(fn, resolve, ...args));

--- a/index.js
+++ b/index.js
@@ -29,12 +29,14 @@ const pLimit = concurrency => {
 
 	const enqueue = (fn, resolve, ...args) => {
 		queue.push(run.bind(null, fn, resolve, ...args));
+
 		(async () => {
-			// This function needs to wait until the next micro-task before comparing
-			// activeCount to concurrency, because activeCount is updated asynchronously
+			// This function needs to wait until the next microtask before comparing
+			// `activeCount` to `concurrency`, because `activeCount` is updated asynchronously
 			// when the run function is dequeued and called. The comparison in the if-statement
-			// needs to happen asynchronously as well to get an up-to-date value for activeCount.
+			// needs to happen asynchronously as well to get an up-to-date value for `activeCount`.
 			await Promise.resolve();
+
 			if (activeCount < concurrency && queue.length > 0) {
 				queue.shift()();
 			}

--- a/test.js
+++ b/test.js
@@ -98,6 +98,10 @@ test('activeCount and pendingCount properties', async t => {
 	t.is(limit.pendingCount, 0);
 
 	const runningPromise1 = limit(() => delay(1000));
+	t.is(limit.activeCount, 0);
+	t.is(limit.pendingCount, 1);
+
+	await Promise.resolve();
 	t.is(limit.activeCount, 1);
 	t.is(limit.pendingCount, 0);
 
@@ -108,6 +112,7 @@ test('activeCount and pendingCount properties', async t => {
 	const immediatePromises = Array.from({length: 5}, () => limit(() => delay(1000)));
 	const delayedPromises = Array.from({length: 3}, () => limit(() => delay(1000)));
 
+	await Promise.resolve();
 	t.is(limit.activeCount, 5);
 	t.is(limit.pendingCount, 3);
 
@@ -121,12 +126,13 @@ test('activeCount and pendingCount properties', async t => {
 	t.is(limit.pendingCount, 0);
 });
 
-test('clearQueue', t => {
+test('clearQueue', async t => {
 	const limit = pLimit(1);
 
 	Array.from({length: 1}, () => limit(() => delay(1000)));
 	Array.from({length: 3}, () => limit(() => delay(1000)));
 
+	await Promise.resolve();
 	t.is(limit.pendingCount, 3);
 	limit.clearQueue();
 	t.is(limit.pendingCount, 0);


### PR DESCRIPTION
This modifies the generator function returned from plimit to always
run functions passed to limit asynchronously.

This is done by modifying the enqueue method to always push the function
provided to the generator function onto the queue and then scheduling a
function to run asynchronously to dequeue and run that function.

I thought using using `Promise.resolve().then()` was a nice way to
schedule that dequeuing function asynchronously because it wasn't too
node-specific or browser-specific, but I'm happy to do something else
like preferring `process.nextTick` and then falling back to `setTimeout`
if `process.nextTick` isn't available.

Closes #22 