### PR TITLE
Fix error on invalid concurrency

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,7 @@ const pTry = require('p-try');
 
 const pLimit = concurrency => {
 	if (!((Number.isInteger(concurrency) || concurrency === Infinity) && concurrency > 0)) {
-		return async () => {
-			throw new TypeError('Expected `concurrency` to be a number from 1 and up');
-		}
+		throw new TypeError('Expected `concurrency` to be a number from 1 and up');
 	}
 
 	const queue = [];

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const pTry = require('p-try');
 
 const pLimit = concurrency => {
 	if (!((Number.isInteger(concurrency) || concurrency === Infinity) && concurrency > 0)) {
-		return Promise.reject(new TypeError('Expected `concurrency` to be a number from 1 and up'));
+		return () => Promise.reject(new TypeError('Expected `concurrency` to be a number from 1 and up'));
 	}
 
 	const queue = [];

--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@ const pTry = require('p-try');
 
 const pLimit = concurrency => {
 	if (!((Number.isInteger(concurrency) || concurrency === Infinity) && concurrency > 0)) {
-		return () => Promise.reject(new TypeError('Expected `concurrency` to be a number from 1 and up'));
+		return async () => {
+			throw new TypeError('Expected `concurrency` to be a number from 1 and up');
+		}
 	}
 
 	const queue = [];

--- a/test.js
+++ b/test.js
@@ -139,9 +139,9 @@ test('clearQueue', async t => {
 });
 
 test('throws on invalid concurrency argument', async t => {
-	await t.throwsAsync(pLimit(0));
-	await t.throwsAsync(pLimit(-1));
-	await t.throwsAsync(pLimit(1.2));
-	await t.throwsAsync(pLimit(undefined));
-	await t.throwsAsync(pLimit(true));
+	await t.throwsAsync(pLimit(0)(() => t.fail()));
+	await t.throwsAsync(pLimit(-1)(() => t.fail()));
+	await t.throwsAsync(pLimit(1.2)(() => t.fail()));
+	await t.throwsAsync(pLimit(undefined)(() => t.fail()));
+	await t.throwsAsync(pLimit(true)(() => t.fail()));
 });

--- a/test.js
+++ b/test.js
@@ -138,10 +138,10 @@ test('clearQueue', async t => {
 	t.is(limit.pendingCount, 0);
 });
 
-test('throws on invalid concurrency argument', async t => {
-	await t.throwsAsync(pLimit(0)(() => t.fail()));
-	await t.throwsAsync(pLimit(-1)(() => t.fail()));
-	await t.throwsAsync(pLimit(1.2)(() => t.fail()));
-	await t.throwsAsync(pLimit(undefined)(() => t.fail()));
-	await t.throwsAsync(pLimit(true)(() => t.fail()));
+test('throws on invalid concurrency argument', t => {
+	t.throws(() => pLimit(0));
+	t.throws(() => pLimit(-1));
+	t.throws(() => pLimit(1.2));
+	t.throws(() => pLimit(undefined));
+	t.throws(() => pLimit(true));
 });

--- a/test.js
+++ b/test.js
@@ -139,9 +139,23 @@ test('clearQueue', async t => {
 });
 
 test('throws on invalid concurrency argument', t => {
-	t.throws(() => pLimit(0));
-	t.throws(() => pLimit(-1));
-	t.throws(() => pLimit(1.2));
-	t.throws(() => pLimit(undefined));
-	t.throws(() => pLimit(true));
+	t.throws(() => {
+		pLimit(0);
+	});
+
+	t.throws(() => {
+		pLimit(-1);
+	});
+
+	t.throws(() => {
+		pLimit(1.2);
+	});
+
+	t.throws(() => {
+		pLimit(undefined);
+	});
+
+	t.throws(() => {
+		pLimit(true);
+	});
 });


### PR DESCRIPTION
Else, passing in an invalid concurrency (in my case, because I wanted to see if `-1` meant "unlimited") produces a confusing error message: both a `limit is not a function` at the point of use, and an `UnhandledPromiseRejectionWarning` from node itself.

An example:

```
const limit = pLimit(userSuppliedValue || someDefault);

...
.map(val => limit(() => doSomething()))
//               ^ TypeError: limit is not a function
...
```