### PR TITLE
Syntax error on catch (for compatability with node v8)

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const pLimit = concurrency => {
 
 		try {
 			await result;
-		} catch {}
+		} catch(error) {}
 
 		next();
 	};


### PR DESCRIPTION
Due to not adding "parameters" failing the compilation of this script 
getting this below error in node version 8* (I know it needs node 10 but this is capable of running in node 8 as some of our projects are running node 8)
also now this is now according to the semantics proposed in http://es5.github.io/#x12.14   😉
SyntaxError: node_modules\p-limit\index.js:30
                } catch {}
                        ^

SyntaxError: Unexpected token {
    at NativeCompileCache._moduleCompile (C:\Users\pe062487\Desktop\MY_Folder\Personal_projects\StokScreenerFilterUpdate\node_modules\v8-compile-cache\v8-compile-cache.js:242:18)
    at Module._compile (C:\Users\pe062487\Desktop\MY_Folder\Personal_projects\StokScreenerFilterUpdate\node_modules\v8-compile-cache\v8-compile-cache.js:186:36)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)