### PR TITLE
feat: improve shift() performance by using a linked list.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict';
 const pTry = require('p-try');
+const yallist = require('yallist');
 
 const pLimit = concurrency => {
 	if (!((Number.isInteger(concurrency) || concurrency === Infinity) && concurrency > 0)) {
 		throw new TypeError('Expected `concurrency` to be a number from 1 and up');
 	}
 
-	const queue = [];
+	const queue = yallist.create();
 	let activeCount = 0;
 
 	const next = () => {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"p-try": "^2.0.0"
+		"p-try": "^2.0.0",
+		"yallist": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
`Array.prototype.shift()` runs in `O(n)` time. By using a linked list instead, both enqueue and dequeue are `O(1)` operations. In practice, I started hitting long delays at about 1,000,000 Promises in the queue.

[`yallist`](https://www.npmjs.com/package/yallist) appears to be the most popular linked list implementation (implementation of [`push()`](https://github.com/isaacs/yallist/blob/master/yallist.js#L137-L151) and [`shift()`](https://github.com/isaacs/yallist/blob/1649cc57394b5affeca2c573943ebe3ed7d39119/yallist.js#L384-L390) for your convenience). Please let me know if you prefer another implementation.

I ran the following on my computer (100,000 Promises in the queue):

```js
const limit = plimit(10000000);
const start = Date.now();
await Promise.all([...Array(100000)].map(_ => limit(async () => Promise.resolve())));
console.log(Date.now() - start, 'plimit');
```

Without this change: ~4300 ms
With this change: ~300 ms

All unit tests pass locally.