### PR TITLE
feat: ios 11 no support optional-catch-binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const pLimit = concurrency => {
 
 		try {
 			await result;
-		} catch {}
+		} catch(e) {}
 
 		next();
 	};


### PR DESCRIPTION
`try{} catch {}` syntax needs to be supported after `es2019`, [see more](https://github.com/tc39/proposal-optional-catch-binding).

I don’t want to introduce the babel library because of the way catch is used, so I hope `p-limit` can be changed back to compatible writing.

