### PR TITLE
Enhance `map` method to accept iterables

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ export type LimitFunction = {
 	@returns A Promise that returns an array of results.
 	*/
 	map: <Input, ReturnType> (
-		array: readonly Input[],
+		array: Iterable<Input> | ArrayLike<Input>,
 		mapperFunction: (input: Input, index: number) => PromiseLike<ReturnType> | ReturnType
 	) => Promise<ReturnType[]>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,16 +24,16 @@ export type LimitFunction = {
 	clearQueue: () => void;
 
 	/**
-	Process an array of inputs with limited concurrency.
+	Process an iterable of inputs with limited concurrency.
 
 	The mapper function receives the item value and its index.
 
-	@param array - An array containing an argument for the given function.
+	@param iterable - An iterable containing an argument for the given function.
 	@param mapperFunction - Promise-returning/async function.
 	@returns A Promise that returns an array of results.
 	*/
 	map: <Input, ReturnType> (
-		array: Iterable<Input> | ArrayLike<Input>,
+		iterable: Iterable<Input>,
 		mapperFunction: (input: Input, index: number) => PromiseLike<ReturnType> | ReturnType
 	) => Promise<ReturnType[]>;
 

--- a/index.js
+++ b/index.js
@@ -82,8 +82,8 @@ export default function pLimit(concurrency) {
 			},
 		},
 		map: {
-			async value(array, function_) {
-				const promises = array.map((value, index) => this(function_, value, index));
+			async value(iterable, function_) {
+				const promises = Array.from(iterable, (value, index) => this(function_, value, index));
 				return Promise.all(promises);
 			},
 		},

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -24,3 +24,7 @@ const lf = limitFunction(async (_a: string) => 'ok', {concurrency: 1});
 expectType<Promise<string>>(lf('input'));
 
 expectError(limitFunction((_a: string) => 'x', {concurrency: 1}));
+
+// LimitFunction.map accepts iterables
+expectType<Promise<string[]>>(limit.map(new Set(['a', 'b', 'c']), async x => x + x));
+expectType<Promise<number[]>>(limit.map([1, 2, 3].values(), async x => x * 2));

--- a/readme.md
+++ b/readme.md
@@ -57,13 +57,13 @@ Any arguments to pass through to `fn`.
 
 Support for passing arguments on to the `fn` is provided in order to be able to avoid creating unnecessary closures. You probably don't need this optimization unless you're pushing a *lot* of functions.
 
-### limit.map(array, mapperFunction)
+### limit.map(iterable, mapperFunction)
 
-Process an array of inputs with limited concurrency.
+Process an iterable of inputs with limited concurrency.
 
 The mapper function receives the item value and its index.
 
-Returns a promise equivalent to `Promise.all(array.map((item, index) => limit(mapperFunction, item, index)))`.
+Returns a promise equivalent to `Promise.all(Array.from(iterable, (item, index) => limit(mapperFunction, item, index)))`.
 
 This is a convenience function for processing inputs that arrive in batches. For more complex use cases, see [p-map](https://github.com/sindresorhus/p-map).
 

--- a/test.js
+++ b/test.js
@@ -190,6 +190,24 @@ test('map passes index and preserves order with concurrency', async t => {
 	t.deepEqual(results, [10, 11, 12, 13, 14]);
 });
 
+test('map accepts an iterable (set)', async t => {
+	const limit = pLimit(2);
+	const inputs = new Set([1, 2, 3, 4]);
+
+	const results = await limit.map(inputs, input => input * 2); // eslint-disable-line unicorn/no-array-method-this-argument
+
+	t.deepEqual(results, [2, 4, 6, 8]);
+});
+
+test('map accepts an iterable (array iterator)', async t => {
+	const limit = pLimit(2);
+	const inputs = [1, 2, 3, 4].values();
+
+	const results = await limit.map(inputs, input => input * 2); // eslint-disable-line unicorn/no-array-method-this-argument
+
+	t.deepEqual(results, [2, 4, 6, 8]);
+});
+
 test('throws on invalid concurrency argument', t => {
 	t.throws(() => {
 		pLimit(0);


### PR DESCRIPTION
This pull request updates the `map` method to accept any iterable, not just arrays. It also adds tests to ensure correct behavior with different types of iterables and updates type definitions to reflect the new functionality.

**Enhancements to iterable support:**

* Updated the implementation of `map` in `index.js` to use `Array.from`, allowing it to accept any iterable, not just arrays.

**Testing improvements:**

* Added tests in `test.js` to verify that `map` works correctly with `Set` and array iterators, ensuring that results are as expected for these iterable types.

**Type definition updates:**

* Updated `index.test-d.ts` to confirm that the type definitions for `limit.map` correctly support generic iterables.