### PR TITLE
docs: use tear down in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ The number of promises that are waiting to run (i.e. their internal `fn` was not
 
 Discard pending promises that are waiting to run.
 
-This might be useful if you want to teardown the queue at the end of your program's lifecycle or discard any function calls referencing an intermediary state of your app.
+This might be useful if you want to tear down the queue at the end of your program's lifecycle or discard any function calls referencing an intermediary state of your app.
 
 Note: This does not cancel promises that are already running.
 


### PR DESCRIPTION
## Summary
- use the two-word verb "tear down" in the README

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- CONTRIBUTING: none found in the repo root or .github on main
- PR template: none found in the repo root or .github on main

## Validation
- Not run (docs-only change)
