### PR TITLE
feat: add pause and resume capabilities to concurrency limit

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,21 @@ export type LimitFunction = {
 	readonly pendingCount: number;
 
 	/**
+	Whether the execution of new queued promises is currently paused.
+	*/
+	readonly isPaused: boolean;
+
+	/**
+	Pause the execution of any queued promises. Already running promises will continue to completion.
+	*/
+	pause: () => void;
+
+	/**
+	Resume the execution of queued promises.
+	*/
+	resume: () => void;
+
+	/**
 	Get or set the concurrency limit.
 	*/
 	concurrency: number;

--- a/index.js
+++ b/index.js
@@ -15,8 +15,13 @@ export default function pLimit(concurrency) {
 
 	const queue = new Queue();
 	let activeCount = 0;
+	let isPaused = false;
 
 	const resumeNext = () => {
+		if (isPaused) {
+			return;
+		}
+
 		// Process the next queued function if we're under the concurrency limit
 		if (activeCount < concurrency && queue.size > 0) {
 			activeCount++;
@@ -74,6 +79,30 @@ export default function pLimit(concurrency) {
 		pendingCount: {
 			get: () => queue.size,
 		},
+		isPaused: {
+			get: () => isPaused,
+		},
+		pause: {
+			value() {
+				isPaused = true;
+			},
+		},
+		resume: {
+			value() {
+				if (!isPaused) {
+					return;
+				}
+
+				isPaused = false;
+
+				queueMicrotask(() => {
+					// eslint-disable-next-line no-unmodified-loop-condition
+					while (activeCount < concurrency && queue.size > 0) {
+						resumeNext();
+					}
+				});
+			},
+		},
 		clearQueue: {
 			value() {
 				if (!rejectOnClear) {
@@ -97,7 +126,7 @@ export default function pLimit(concurrency) {
 
 				queueMicrotask(() => {
 					// eslint-disable-next-line no-unmodified-loop-condition
-					while (activeCount < concurrency && queue.size > 0) {
+					while (!isPaused && activeCount < concurrency && queue.size > 0) {
 						resumeNext();
 					}
 				});

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -17,6 +17,9 @@ expectType<Promise<string>>(limit(async (_a: string, _b: number) => '', 'test', 
 
 expectType<number>(limit.activeCount);
 expectType<number>(limit.pendingCount);
+expectType<boolean>(limit.isPaused);
+expectType<void>(limit.pause());
+expectType<void>(limit.resume());
 
 expectType<void>(limit.clearQueue());
 expectType<void>(limitWithRejectOnClear.clearQueue());

--- a/test.js
+++ b/test.js
@@ -355,3 +355,76 @@ test('limitFunction()', async t => {
 
 	await Promise.all(input);
 });
+
+test('pause and resume queue', async t => {
+	const limit = pLimit(1);
+	const results = [];
+
+	const promise1 = limit(async () => {
+		await delay(50);
+		results.push(1);
+	});
+
+	const promise2 = limit(async () => {
+		await delay(50);
+		results.push(2);
+	});
+
+	const promise3 = limit(async () => {
+		await delay(50);
+		results.push(3);
+	});
+
+	t.false(limit.isPaused);
+
+	// Pause immediately
+	limit.pause();
+	t.true(limit.isPaused);
+
+	// Wait for the active count to be processed.
+	// Since concurrency is 1, only the first promise (which was already run) will finish.
+	await delay(120);
+
+	t.deepEqual(results, [1]);
+	t.is(limit.activeCount, 0);
+	t.is(limit.pendingCount, 2);
+
+	// Resume the execution
+	limit.resume();
+	t.false(limit.isPaused);
+
+	await Promise.all([promise1, promise2, promise3]);
+	t.deepEqual(results, [1, 2, 3]);
+});
+
+test('changing concurrency while paused does not execute queued tasks', async t => {
+	const limit = pLimit(1);
+	const results = [];
+
+	const promise1 = limit(async () => {
+		await delay(50);
+		results.push(1);
+	});
+
+	const promise2 = limit(async () => {
+		await delay(50);
+		results.push(2);
+	});
+
+	limit.pause();
+
+	// Increase concurrency while paused
+	limit.concurrency = 3;
+
+	await delay(100);
+
+	// Only promise 1 should have finished because the queue was paused
+	t.deepEqual(results, [1]);
+	t.is(limit.activeCount, 0);
+	t.is(limit.pendingCount, 1);
+
+	// Resume queue
+	limit.resume();
+	await Promise.all([promise1, promise2]);
+	t.deepEqual(results, [1, 2]);
+});


### PR DESCRIPTION
This PR adds `pause()`, `resume()` and `isPaused` properties to the concurrency limit function. This allows developers to temporarily halt the execution of queued tasks (while currently executing tasks run to completion) and resume them later. It is fully covered by new unit tests and typed.