### PR TITLE
Fix detached limit.map calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ export default function pLimit(concurrency) {
 		},
 		map: {
 			async value(iterable, function_) {
-				const promises = Array.from(iterable, (value, index) => this(function_, value, index));
+				const promises = Array.from(iterable, (value, index) => generator(function_, value, index));
 				return Promise.all(promises);
 			},
 		},

--- a/test.js
+++ b/test.js
@@ -221,6 +221,26 @@ test('map', async t => {
 	t.deepEqual(results, [2, 3, 4, 5, 6, 7, 8]);
 });
 
+test('map works when detached from the limit', async t => {
+	const limit = pLimit(1);
+	const {map} = limit;
+	let running = 0;
+	let maxRunning = 0;
+	const mapper = async input => {
+		running++;
+		maxRunning = Math.max(maxRunning, running);
+		await delay(10);
+		running--;
+		return input * 2;
+	};
+
+	const directResult = limit(mapper, 1);
+	const mapResult = map([2, 3], mapper);
+
+	t.deepEqual(await Promise.all([directResult, mapResult]), [2, [4, 6]]);
+	t.is(maxRunning, 1);
+});
+
 test('map passes index and preserves order with concurrency', async t => {
 	const limit = pLimit(3);
 	const inputs = [10, 10, 10, 10, 10];


### PR DESCRIPTION
## Summary

- make `limit.map` use the limiter it belongs to instead of its call-time receiver
- cover detached `map` calls sharing the limiter's configured concurrency with direct tasks

## Problem

`LimitFunction.map` is exposed as a callable function property, but its implementation invokes the limiter through dynamic `this`. A valid detached call such as `const {map} = limit` therefore rejects with `TypeError: this is not a function`.

## Fix

Use the closed-over `generator` function when scheduling mapped items. This preserves the existing concurrency, ordering, iterable, and index behavior without requiring a bound receiver.

The regression test combines a direct limiter call with a detached `map` call and verifies their shared maximum concurrency remains at the configured limit.

## Testing

- `npm exec ava -- --match='map works when detached from the limit'`
- `npm exec ava`
- AVA suite on Node.js 20, 22, and 24
- `npm exec tsd`
- `npm exec xo -- index.js test.js`

The aggregate `npm test` command was also attempted. On this Windows checkout, XO reports its existing TypeScript project-service lookup error for `index.d.ts` and `index.test-d.ts`; the same error occurs on the untouched base. The changed JavaScript files pass XO.
